### PR TITLE
(ansi-term PR 65): Replace "cfg(test)" with "cfg(doctest)" for readme testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,8 +238,14 @@
 #![warn(trivial_casts, trivial_numeric_casts)]
 #![warn(unused_extern_crates, unused_qualifications)]
 
-#[cfg(test)]
-doc_comment::doctest!("../README.md");
+#[cfg(target_os="windows")]
+extern crate winapi;
+#[cfg(doctest)]
+#[macro_use]
+extern crate doc_comment;
+
+#[cfg(doctest)]
+doctest!("../README.md");
 
 mod ansi;
 pub use crate::ansi::{Prefix, Infix, Suffix};


### PR DESCRIPTION
https://github.com/ogham/rust-ansi-term/pull/65