### PR TITLE
(ansi-term PR 70): Fix Colour prefix doc examples

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -239,7 +239,7 @@ impl Colour {
     /// use ansi_term::Colour::Green;
     ///
     /// assert_eq!("\x1b[0m",
-    ///            Green.suffix().to_string());
+    ///            Green.prefix().to_string());
     /// ```
     pub fn prefix(self) -> Prefix {
         Prefix(self.normal())


### PR DESCRIPTION
https://github.com/ogham/rust-ansi-term/pull/70