### PR TITLE
(ansi-term PR 76): Add a no-op `enable_ansi_support` for non-windows platforms

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -59,3 +59,10 @@ pub fn enable_ansi_support() -> Result<(), u32> {
 
     return Ok(());
 }
+
+/// Enable ANSI support on Windows 10. This is a no-op on non-windows platforms
+#[cfg(not(windows))]
+#[inline]
+pub fn enable_ansi_support() -> Result<(), u32> {
+    Ok(())
+}


### PR DESCRIPTION
https://github.com/ogham/rust-ansi-term/pull/76

Resolves https://github.com/ogham/rust-ansi-term/issues/30