### PR TITLE
(ansi-term PR 80): Add "bright" builtin codes and tests.

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -98,6 +98,15 @@ impl Colour {
             Colour::Purple     => write!(f, "35"),
             Colour::Cyan       => write!(f, "36"),
             Colour::White      => write!(f, "37"),
+
+            Colour::BrightBlack      => write!(f, "90"),
+            Colour::BrightRed        => write!(f, "91"),
+            Colour::BrightGreen      => write!(f, "92"),
+            Colour::BrightYellow     => write!(f, "93"),
+            Colour::BrightBlue       => write!(f, "94"),
+            Colour::BrightPurple     => write!(f, "95"),
+            Colour::BrightCyan       => write!(f, "96"),
+            Colour::BrightWhite      => write!(f, "97"),
             Colour::Fixed(num) => write!(f, "38;5;{}", &num),
             Colour::RGB(r,g,b) => write!(f, "38;2;{};{};{}", &r, &g, &b),
         }
@@ -113,6 +122,14 @@ impl Colour {
             Colour::Purple     => write!(f, "45"),
             Colour::Cyan       => write!(f, "46"),
             Colour::White      => write!(f, "47"),
+            Colour::BrightBlack      => write!(f, "100"),
+            Colour::BrightRed        => write!(f, "101"),
+            Colour::BrightGreen      => write!(f, "102"),
+            Colour::BrightYellow     => write!(f, "103"),
+            Colour::BrightBlue       => write!(f, "104"),
+            Colour::BrightPurple     => write!(f, "105"),
+            Colour::BrightCyan       => write!(f, "106"),
+            Colour::BrightWhite      => write!(f, "107"),
             Colour::Fixed(num) => write!(f, "48;5;{}", &num),
             Colour::RGB(r,g,b) => write!(f, "48;2;{};{};{}", &r, &g, &b),
         }
@@ -456,6 +473,8 @@ mod test {
     test!(hyperlink_plain:       Style::new().hyperlink("url");     "hi" => "\x1B[m\x1B]8;;url\x1B\\hi\x1B]8;;\x1B\\\x1B[0m");
     test!(hyperlink_color:       Blue.hyperlink("url");             "hi" => "\x1B[34m\x1B]8;;url\x1B\\hi\x1B]8;;\x1B\\\x1B[0m");
     test!(hyperlink_style:       Blue.underline().hyperlink("url"); "hi" => "\x1B[4;34m\x1B]8;;url\x1B\\hi\x1B]8;;\x1B\\\x1B[0m");
+    test!(brightgreen:              BrightGreen;                       "hi" => "\x1B[92mhi\x1B[0m");
+    test!(brightred_on_brightblue:  BrightRed.on(BrightBlue);          "hi" => "\x1B[104;91mhi\x1B[0m");
 
     #[test]
     fn test_infix() {

--- a/src/style.rs
+++ b/src/style.rs
@@ -305,6 +305,36 @@ pub enum Colour {
     /// hard to read on terminals with light backgrounds.
     White,
 
+    /// Colour #8 (foreground code `30`, background code `40`).
+    ///
+    /// This is not necessarily the background colour, and using it as one may
+    /// render the text hard to read on terminals with dark backgrounds.
+    BrightBlack,
+
+    /// Colour #9 (foreground code `91`, background code `101`).
+    BrightRed,
+
+    /// Colour #10 (foreground code `92`, background code `102`).
+    BrightGreen,
+
+    /// Colour #11 (foreground code `93`, background code `103`).
+    BrightYellow,
+
+    /// Colour #12 (foreground code `94`, background code `104`).
+    BrightBlue,
+
+    /// Colour #13 (foreground code `95`, background code `105`).
+    BrightPurple,
+
+    /// Colour #14 (foreground code `96`, background code `106`).
+    BrightCyan,
+
+    /// Colour #15 (foreground code `97`, background code `107`).
+    ///
+    /// As above, this is not necessarily the foreground colour, and may be
+    /// hard to read on terminals with light backgrounds.
+    BrightWhite,
+
     /// A colour number from 0 to 255, for use in 256-colour terminal
     /// environments.
     ///
@@ -511,6 +541,14 @@ impl Colour {
             Self::Purple => Ok(5),
             Self::Cyan => Ok(6),
             Self::White => Ok(7),
+            Self::BrightBlack => Ok(8),
+            Self::BrightRed => Ok(9),
+            Self::BrightGreen => Ok(10),
+            Self::BrightYellow => Ok(11),
+            Self::BrightBlue => Ok(12),
+            Self::BrightPurple => Ok(13),
+            Self::BrightCyan => Ok(14),
+            Self::BrightWhite => Ok(15),
             Self::Fixed(idx) => Ok(idx),
             Self::RGB(r, g, b) => Err((r, g, b))
         }


### PR DESCRIPTION
https://github.com/ogham/rust-ansi-term/pull/80