### PR TITLE
refactor: add minor changes, some from nu_ansi_term

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -26,8 +26,12 @@ impl Style {
 
         {
             let mut write_char = |c| {
-                if written_anything { write!(f, ";")?; }
+                if written_anything {
+                    write!(f, ";")?;
+                }
                 written_anything = true;
+                #[cfg(feature = "gnu_legacy")]
+                write!(f, "0")?;
                 write!(f, "{}", c)?;
                 Ok(())
             };
@@ -98,15 +102,16 @@ impl Colour {
             Colour::Purple     => write!(f, "35"),
             Colour::Cyan       => write!(f, "36"),
             Colour::White      => write!(f, "37"),
+            Colour::Default    => write!(f, "39"),
 
-            Colour::BrightBlack      => write!(f, "90"),
+            Colour::DarkGray         => write!(f, "90"),
             Colour::BrightRed        => write!(f, "91"),
             Colour::BrightGreen      => write!(f, "92"),
             Colour::BrightYellow     => write!(f, "93"),
             Colour::BrightBlue       => write!(f, "94"),
             Colour::BrightPurple     => write!(f, "95"),
             Colour::BrightCyan       => write!(f, "96"),
-            Colour::BrightWhite      => write!(f, "97"),
+            Colour::BrightGray       => write!(f, "97"),
             Colour::Fixed(num) => write!(f, "38;5;{}", &num),
             Colour::RGB(r,g,b) => write!(f, "38;2;{};{};{}", &r, &g, &b),
         }
@@ -122,14 +127,16 @@ impl Colour {
             Colour::Purple     => write!(f, "45"),
             Colour::Cyan       => write!(f, "46"),
             Colour::White      => write!(f, "47"),
-            Colour::BrightBlack      => write!(f, "100"),
+            Colour::Default    => write!(f, "49"),
+
+            Colour::DarkGray         => write!(f, "100"),
             Colour::BrightRed        => write!(f, "101"),
             Colour::BrightGreen      => write!(f, "102"),
             Colour::BrightYellow     => write!(f, "103"),
             Colour::BrightBlue       => write!(f, "104"),
             Colour::BrightPurple     => write!(f, "105"),
             Colour::BrightCyan       => write!(f, "106"),
-            Colour::BrightWhite      => write!(f, "107"),
+            Colour::BrightGray      => write!(f, "107"),
             Colour::Fixed(num) => write!(f, "48;5;{}", &num),
             Colour::RGB(r,g,b) => write!(f, "48;2;{};{};{}", &r, &g, &b),
         }

--- a/src/display.rs
+++ b/src/display.rs
@@ -115,8 +115,12 @@ impl<'a, S: 'a + ToOwned + ?Sized> ANSIGenericString<'a, S>
     pub fn style_ref_mut(&mut self) -> &mut Style {
         &mut self.style
     }
-}
+    /// Directly access the string
+    pub fn as_str(&self) -> &S {
+        self.string.as_ref()
+    }
 
+}
 impl<'a, S: 'a + ToOwned + ?Sized> Deref for ANSIGenericString<'a, S>
 where <S as ToOwned>::Owned: fmt::Debug {
     type Target = S;

--- a/src/style.rs
+++ b/src/style.rs
@@ -309,7 +309,7 @@ pub enum Colour {
     ///
     /// This is not necessarily the background colour, and using it as one may
     /// render the text hard to read on terminals with dark backgrounds.
-    BrightBlack,
+    DarkGray,
 
     /// Colour #9 (foreground code `91`, background code `101`).
     BrightRed,
@@ -333,7 +333,7 @@ pub enum Colour {
     ///
     /// As above, this is not necessarily the foreground colour, and may be
     /// hard to read on terminals with light backgrounds.
-    BrightWhite,
+    BrightGray,
 
     /// A colour number from 0 to 255, for use in 256-colour terminal
     /// environments.
@@ -355,6 +355,10 @@ pub enum Colour {
 
     /// A 24-bit RGB color, as specified by ISO-8613-3.
     RGB(u8, u8, u8),
+
+    /// Default colour (foreground code `39`, background code `49`).
+    // #[default]
+    Default,
 }
 
 
@@ -541,16 +545,17 @@ impl Colour {
             Self::Purple => Ok(5),
             Self::Cyan => Ok(6),
             Self::White => Ok(7),
-            Self::BrightBlack => Ok(8),
+            Self::DarkGray => Ok(8),
             Self::BrightRed => Ok(9),
             Self::BrightGreen => Ok(10),
             Self::BrightYellow => Ok(11),
             Self::BrightBlue => Ok(12),
             Self::BrightPurple => Ok(13),
             Self::BrightCyan => Ok(14),
-            Self::BrightWhite => Ok(15),
+            Self::BrightGray => Ok(15),
             Self::Fixed(idx) => Ok(idx),
-            Self::RGB(r, g, b) => Err((r, g, b))
+            Self::RGB(r, g, b) => Err((r, g, b)),
+            Self::Default => Ok(16),
         }
     }
 }


### PR DESCRIPTION
This is I believe all we need to publish the first release, and migrate Eza over to this new maintained version. It has the syntax upgrades from the first commit, it includes the bright colors from #12, with BrightBlack and BrightWhite more appropriately named, and the Default ANSI color added. 
