### PR TITLE
chore: revert commit e83da1d "Add hyperlink support"

### DIFF
--- a/src/difference.rs
+++ b/src/difference.rs
@@ -3,7 +3,7 @@ use super::Style;
 
 /// When printing out one coloured string followed by another, use one of
 /// these rules to figure out which *extra* control codes need to be sent.
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Copy, Debug)]
 pub enum Difference {
 
     /// Print out the control codes specified by this style to end up looking
@@ -13,11 +13,6 @@ pub enum Difference {
     /// Converting between these two is impossible, so just send a reset
     /// command and then the second string's styles.
     Reset,
-
-    /// Converting between these two is impossible, and the first includes a
-    /// hyperlink, so send a reset and a hyperlink reset, then the second
-    /// string's styles.
-    ResetHyperlink,
 
     /// The before style is exactly the same as the after style, so no further
     /// control codes need to be printed.
@@ -50,10 +45,6 @@ impl Difference {
 
         if first == next {
             return NoDifference;
-        }
-
-        if first.hyperlink_url.is_some() && next.hyperlink_url.is_none() {
-            return ResetHyperlink;
         }
 
         // Cannot un-bold, so must Reset.
@@ -142,10 +133,6 @@ impl Difference {
             extra_styles.background = next.background;
         }
 
-        if first.hyperlink_url != next.hyperlink_url {
-            extra_styles.hyperlink_url = next.hyperlink_url.clone();
-        }
-
         ExtraStyles(extra_styles)
     }
 }
@@ -183,14 +170,10 @@ mod test {
     test!(addition_of_hidden:         style(); style().hidden()         => ExtraStyles(style().hidden()));
     test!(addition_of_reverse:        style(); style().reverse()        => ExtraStyles(style().reverse()));
     test!(addition_of_strikethrough:  style(); style().strikethrough()  => ExtraStyles(style().strikethrough()));
-    test!(addition_of_hyperlink:      style(); style().hyperlink("x")   => ExtraStyles(style().hyperlink("x")));
 
     test!(removal_of_strikethrough:   style().strikethrough(); style()  => Reset);
     test!(removal_of_reverse:         style().reverse();       style()  => Reset);
     test!(removal_of_hidden:          style().hidden();        style()  => Reset);
     test!(removal_of_dimmed:          style().dimmed();        style()  => Reset);
     test!(removal_of_blink:           style().blink();         style()  => Reset);
-    test!(removal_of_hyperlink:       style().hyperlink("x");  style()  => ResetHyperlink);
-
-    test!(change_of_hyperlink: style().hyperlink("url1"); style().hyperlink("url2") => ExtraStyles(style().hyperlink("url2")));
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -3,10 +3,10 @@ use std::fmt;
 use std::io;
 use std::ops::Deref;
 
-use ansi::RESET;
-use difference::Difference;
-use style::{Style, Colour};
-use write::AnyWrite;
+use crate::ansi::RESET;
+use crate::difference::Difference;
+use crate::style::{Style, Colour};
+use crate::write::AnyWrite;
 
 
 /// An `ANSIGenericString` includes a generic string type and a `Style` to

--- a/src/display.rs
+++ b/src/display.rs
@@ -3,10 +3,10 @@ use std::fmt;
 use std::io;
 use std::ops::Deref;
 
-use crate::ansi::{RESET, RESET_HYPERLINK};
-use crate::difference::Difference;
-use crate::style::{Style, Colour};
-use crate::write::AnyWrite;
+use ansi::RESET;
+use difference::Difference;
+use style::{Style, Colour};
+use write::AnyWrite;
 
 
 /// An `ANSIGenericString` includes a generic string type and a `Style` to
@@ -35,7 +35,7 @@ impl<'a, S: 'a + ToOwned + ?Sized> Clone for ANSIGenericString<'a, S>
 where <S as ToOwned>::Owned: fmt::Debug {
     fn clone(&self) -> ANSIGenericString<'a, S> {
         ANSIGenericString {
-            style: self.style.clone(),
+            style: self.style,
             string: self.string.clone(),
         }
     }
@@ -161,12 +161,12 @@ impl Style {
 
     /// Paints the given text with this colour, returning an ANSI string.
     #[must_use]
-    pub fn paint<'a, I, S: 'a + ToOwned + ?Sized>(&self, input: I) -> ANSIGenericString<'a, S>
+    pub fn paint<'a, I, S: 'a + ToOwned + ?Sized>(self, input: I) -> ANSIGenericString<'a, S>
     where I: Into<Cow<'a, S>>,
           <S as ToOwned>::Owned: fmt::Debug {
         ANSIGenericString {
             string: input.into(),
-            style:  self.clone(),
+            style:  self,
         }
     }
 }
@@ -258,19 +258,19 @@ where <S as ToOwned>::Owned: fmt::Debug, &'a S: AsRef<[u8]> {
             match Difference::between(&window[0].style, &window[1].style) {
                 ExtraStyles(style) => write!(w, "{}", style.prefix())?,
                 Reset              => write!(w, "{}{}", RESET, window[1].style.prefix())?,
-                ResetHyperlink     => {
-                    write!(w, "{}{}{}", RESET_HYPERLINK, RESET, window[1].style.prefix())?;
-                }
                 NoDifference       => {/* Do nothing! */},
             }
 
             w.write_str(&window[1].string)?;
         }
 
-        // Write any final reset strings needed after all of the ANSIStrings
-        // have been written.
+        // Write the final reset string after all of the ANSIStrings have been
+        // written, *except* if the last one has no styles, because it would
+        // have already been written by this point.
         if let Some(last) = self.0.last() {
-            write!(w, "{}", last.style.suffix())?;
+            if !last.style.is_plain() {
+                write!(w, "{}", RESET)?;
+            }
         }
 
         Ok(())

--- a/src/style.rs
+++ b/src/style.rs
@@ -488,6 +488,35 @@ impl Colour {
     pub fn on(self, background: Colour) -> Style {
         Style { foreground: Some(self), background: Some(background), .. Style::default() }
     }
+    
+    /// Returns index in 256-colour ANSI palette or red, green and blue
+    /// components of the colour.
+    ///
+    /// Variants `Black` through `White` are treated as indexes 0 through 7.
+    /// Variant `Fixed` returns the index stored in it.  Lastly, `RGB` variant
+    /// is returned as a three-element tuple.
+    pub fn into_index(self) -> Result<u8, (u8, u8, u8)> {
+        match self {
+            Self::Black => Ok(0),
+            Self::Red => Ok(1),
+            Self::Green => Ok(2),
+            Self::Yellow => Ok(3),
+            Self::Blue => Ok(4),
+            Self::Purple => Ok(5),
+            Self::Cyan => Ok(6),
+            Self::White => Ok(7),
+            Self::BrightBlack => Ok(8),
+            Self::BrightRed => Ok(9),
+            Self::BrightGreen => Ok(10),
+            Self::BrightYellow => Ok(11),
+            Self::BrightBlue => Ok(12),
+            Self::BrightPurple => Ok(13),
+            Self::BrightCyan => Ok(14),
+            Self::BrightWhite => Ok(15),
+            Self::Fixed(idx) => Ok(idx),
+            Self::RGB(r, g, b) => Err((r, g, b))
+        }
+    }
 }
 
 impl From<Colour> for Style {


### PR DESCRIPTION
Unfortunately, having to implement clone manually for Style would break the API as several structs in Eza have style as a field and can no longer derive clone for the entire object.

This reverts commit e83da1dd5915ee4fd4af0f84d4448023fcb72b95.