### PR TITLE
Fix description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Big shout-out to its creator [Benjamin Sago](https://github.com/ogham).
 # Installation
 
 Disclaimer:
-This crate is still in development, and is not yet available on crates.io
+This crate is still in development.
 
 #### We promise to keep the API stable, and not break anything that is already working in the original crate.
 

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -16,6 +16,7 @@ pub enum Difference {
 
     /// The before style is exactly the same as the after style, so no further
     /// control codes need to be printed.
+    #[allow(clippy::enum_variant_names)]
     NoDifference,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,7 @@ pub use crate::display::*;
 mod write;
 
 mod windows;
+#[cfg(target_os="windows")]
 pub use crate::windows::*;
 
 mod util;


### PR DESCRIPTION
Crate does appear to be on crates.io: https://crates.io/crates/ansiterm/